### PR TITLE
WF PokerBot TomBot UserBot MatchHandler - Updates and New File

### DIFF
--- a/MatchHandler.py
+++ b/MatchHandler.py
@@ -1,0 +1,70 @@
+from texasholdem import TexasHoldEm
+from typing import Sequence
+from PokerBot import PokerBot
+
+######################## MATCH HANDLER CLASS DEFINITION ########################
+
+# class that automates running Texas Holdem' matches and recording match
+# histories. should be useful regarding the training and evaluations
+# of our agents, as well as letting users play against them.
+class MatchHandler:
+  def __init__(self, bots:Sequence[PokerBot]):
+    # cover too few bots (at least two required)
+    if (len(bots) < 2):
+      raise Exception("too few bots passed in, at least two required")
+    self.bots = bots
+    self.num_bots = len(self.bots)
+    self.match_histories = None # TODO: IMPLEMENT ME.
+  
+  # create a TexasHoldEm object using arguments as match parameters and assign
+  # all bots to the match. only useful in conjunction with run_round() method
+  # for step-by-step matches or when called internally by run_match() method.
+  def start_game(self, buyin:int, big_blind:int, small_blind:int):
+    self.game = TexasHoldEm(buyin, big_blind, small_blind, self.num_bots)
+    for i in range(self.num_bots):
+      self.bots[i].set_game(self.game, i)
+  
+  # run through a single round of play in the current match, if it exists and
+  # hasn't already ended. can only be used after calling start_game() method,
+  # or when called internally by run_match() method.
+  def run_round(self):
+    #
+    ########## COVER EXCEPTIONS ##########
+    if (self.game is None):
+      raise Exception("no game has been created, call start_game() method")
+    if (not self.game.is_game_running()):
+      raise Exception("current game has ended, call start_game() method")
+    if (self.game.is_hand_running()):
+      raise Exception("there is a hand already running, if you see this, " \
+                      "something went seriously wrong")
+    #
+    ########## RUN THE ROUND ##########
+    self.game.start_hand()
+    # return early if match has ended (last round decided the match winner)
+    if (not self.game.is_game_running()):
+      return None
+    # otherwise, run the round like normal
+    while (self.game.is_hand_running()):
+      self.bots[self.game.current_player].make_decision()
+    return None
+  
+  # create a TexasHoldEm object using arguments as match parameters, and run
+  # through the entire match using the bots passed in at the handler's
+  # instanciation. records the match history if desired.
+  # TODO: IMPLEMENT RECORDING MATCH HISTORY
+  def run_match(self, buyin:int, big_blind:int, small_blind:int,
+                record_history:bool = False):
+    # instanciate game and assign all bots to the game
+    self.start_game(buyin, big_blind, small_blind)
+    # run rounds until match ends
+    while (self.game.is_game_running()):
+      self.run_round()
+    return None
+  
+  # perform run_match num_matches times. records the match history if desired.
+  # TODO: IMPLEMENT RECORDING MATCH HISTORY
+  def run_matches(self, num_matches:int, buyin:int, big_blind:int,
+                  small_blind:int, record_history:bool = False):
+    for i in range(num_matches):
+      self.run_match(buyin, big_blind, small_blind, record_history)
+    return None

--- a/PokerBot.py
+++ b/PokerBot.py
@@ -7,11 +7,8 @@ from texasholdem import TexasHoldEm
 # operate off subclasses of this parent class (hopefully) and we can have a
 # standardized and modular way to implement our other bots.
 class PokerBot(ABC):
-  def __init__(self, game:TexasHoldEm, player_num:int):
-    if (player_num + 1 > game.max_players):
-      raise ValueError("argument player_num too large for game")
-    self.game = game
-    self.player_num = player_num
+  def __init__(self):
+    pass
   
   # sets the match that the bot is playing, as well as which player number it
   # is. allows bots to switch what game they're playing in, or switch which
@@ -27,10 +24,17 @@ class PokerBot(ABC):
   
   # shorthand helper function to get the bot's chips for those curious users
   def get_num_chips(self):
+    # cover game not set
+    if (self.game is None):
+      raise Exception( \
+        "TexasHoldEm object not set, call set_game() method first")
     return self.game.players[self.player_num].chips
   
   # shorthand helper function to get the bot's cards for those curious users
   def get_cards(self):
+    # cover game not set
+    if (self.game is None):
+      raise Exception("game member not set, call set_game() method first")
     return self.game.get_hand(self.player_num)
   
   # returns the bot's parameters, so that saving is more efficient. must be

--- a/TomBot.py
+++ b/TomBot.py
@@ -22,6 +22,10 @@ class TomBot(PokerBot):
   def make_decision(self):
     #
     ########## COVER EXCEPTIONS ##########
+    # cover self.game not being set
+    if (self.game is None):
+      raise Exception( \
+        "TexasHoldEm object not set, call set_game() method first")
     # cover self.game not having hand running
     if (not (self.game.is_game_running() and self.game.is_hand_running())):
       raise Exception("TexasHoldEm object does not have hand running")

--- a/UserBot.py
+++ b/UserBot.py
@@ -18,6 +18,10 @@ class UserBot(PokerBot):
   def make_decision(self):
     #
     ########## COVER EXCEPTIONS ##########
+    # cover self.game not being set
+    if (self.game is None):
+      raise Exception( \
+        "TexasHoldEm object not set, call set_game() method first")
     # cover self.game not having hand running
     if (not (self.game.is_game_running() and self.game.is_hand_running())):
       raise Exception("TexasHoldEm object does not have hand running")
@@ -27,7 +31,7 @@ class UserBot(PokerBot):
         f"TomBot (player {self.player_num}) called to play out of turn order " \
           f"(it is player {self.game.current_player}'s turn)")
     #
-    ########## MAKE DECISION ##########
+    ########## PROMPT USER TO MAKE DECISION ##########
     # show user game state information and prompt to input decision
     opponent_chips = []
     for i in range(self.game.max_players):
@@ -41,9 +45,11 @@ class UserBot(PokerBot):
     print(f"Your Cards: {self.game.get_hand(self.player_num)}")
     print(f"Community Cards: {self.game.board}")
     user_decision = str(input("What will you do (c/r/f/a)?:"))
-    # try to make user_decision
+    #
+    ########## TRY TO MAKE USER DECISION ##########
+    # branch on user decision
     if (user_decision == "c"):
-      # try to call/check
+      ##### TRY TO CALL/CHECK #####
       if (self.game.validate_move(action = ActionType.CALL)):
         self.game.take_action(ActionType.CALL)
         return None
@@ -53,7 +59,7 @@ class UserBot(PokerBot):
       else:
         raise Exception("illegal decision made")
     elif (user_decision == "r"):
-      # try to raise
+      ##### TRY TO RAISE #####
       user_raise_amount = int(input("How much to raise by?:"))
       if (self.game.validate_move(action = ActionType.RAISE,
                                   value = user_raise_amount)):
@@ -62,14 +68,14 @@ class UserBot(PokerBot):
       else:
         raise Exception("illegal decision made")
     elif (user_decision == "f"):
-      # try to fold
+      ##### TRY TO FOLD #####
       if (self.game.validate_move(action = ActionType.FOLD)):
         self.game.take_action(ActionType.FOLD)
         return None
       else:
         raise Exception("illegal decision made")
     elif (user_decision == "a"):
-      # try to go all in
+      ##### TRY TO GO ALL IN #####
       if (self.game.validate_move(action = ActionType.ALL_IN)):
         self.game.take_action(ActionType.ALL_IN)
         return None


### PR DESCRIPTION
PokerBot, TomBot, and UserBot have been reconfigured to not require a TexasHoldEm object at instantiation, and now instead completely rely upon their shared set_game() method to set the game and player number within the game that they take on.

This was done to facilitate the successful implementation of MatchHandler, an object that creates and wraps around TexasHoldEm instances, allowing for matches to be ran effortlessly using a collection of PokerBot child class instances that are passed by reference during instantiation. Matches can be ran one round at a time, or one match at a time, or multiple matches back to back.

I plan to update MatchHandler to be able to record match data in the future, but the details of that feature require discussion.